### PR TITLE
Remove `none` case from EquatableFilter and ComparableFilter in favor of using Optionals

### DIFF
--- a/Sources/Filter/Comparable/ComparableFilter.swift
+++ b/Sources/Filter/Comparable/ComparableFilter.swift
@@ -20,7 +20,6 @@ public enum ComparableFilter<T: Comparable>: Equatable {
     case lessThanOrEqualTo(T)
     case greaterThan(T)
     case greaterThanOrEqualTo(T)
-    case none // Always evaluates to true
     indirect case or(Self, Self)
     indirect case orMulti([Self])
     indirect case and(Self, Self)
@@ -31,18 +30,18 @@ public enum ComparableFilter<T: Comparable>: Equatable {
     /// A wrapper for ComparableFilter when comparing an optional type.
     public enum Optional: Equatable {
         case orNil(ComparableFilter<T>)
-        case notNil(ComparableFilter<T>)
+        case notNil(ComparableFilter<T>?)
         case isNil
 
         /// Returns the wrapped ComparableFilter from `self`.
-        public var unwrapped: ComparableFilter<T> {
+        public var unwrapped: ComparableFilter<T>? {
             switch self {
             case let .orNil(unwrapped):
                 return unwrapped
             case let .notNil(unwrapped):
                 return unwrapped
             case .isNil:
-                return .none
+                return nil
             }
         }
     }

--- a/Sources/Filter/Equatable/EquatableFilter.swift
+++ b/Sources/Filter/Equatable/EquatableFilter.swift
@@ -17,7 +17,6 @@ import Foundation
 /// is maintained so that the outer most is evaluated first.
 public enum EquatableFilter<T: Equatable>: Equatable {
     case equalTo(T)
-    case none // Always evaluates to true
     indirect case or(Self, Self)
     indirect case orMulti([Self])
     indirect case and(Self, Self)
@@ -27,18 +26,18 @@ public enum EquatableFilter<T: Equatable>: Equatable {
     /// A wrapper for EquatableFilter when comparing an optional type.
     public enum Optional: Equatable {
         case orNil(EquatableFilter<T>)
-        case notNil(EquatableFilter<T>)
+        case notNil(EquatableFilter<T>?)
         case isNil
 
         /// Returns the wrapped EquatableFilter from `self`.
-        public var unwrapped: EquatableFilter<T> {
+        public var unwrapped: EquatableFilter<T>? {
             switch self {
             case let .orNil(unwrapped):
                 return unwrapped
             case let .notNil(unwrapped):
                 return unwrapped
             case .isNil:
-                return .none
+                return nil
             }
         }
     }

--- a/Sources/FilterClosure/Closure+ComparablePredicate.swift
+++ b/Sources/FilterClosure/Closure+ComparablePredicate.swift
@@ -9,8 +9,6 @@
 import Filter
 import Foundation
 
-// swiftlint:disable cyclomatic_complexity
-
 extension Closure: ComparablePredicate where Value: Comparable {
     /// Creates a closure `(Self) -> Bool` from a ComparableFilter
     ///
@@ -27,8 +25,6 @@ extension Closure: ComparablePredicate where Value: Comparable {
             return { $0[keyPath: keyPath] > bound }
         case let .greaterThanOrEqualTo(bound):
             return { $0[keyPath: keyPath] >= bound }
-        case .none:
-            return { _ in true }
         case let .or(lhs, rhs):
             let lhsClosure = Self.build(from: lhs, on: keyPath)
             let rhsClosure = Self.build(from: rhs, on: keyPath)
@@ -53,5 +49,3 @@ extension Closure: ComparablePredicate where Value: Comparable {
         }
     }
 }
-
-// swiftlint:enable cyclomatic_complexity

--- a/Sources/FilterClosure/Closure+EquatablePredicate.swift
+++ b/Sources/FilterClosure/Closure+EquatablePredicate.swift
@@ -19,8 +19,6 @@ extension Closure: EquatablePredicate where Value: Equatable {
         switch filter {
         case let .equalTo(requiredValue):
             return { $0[keyPath: keyPath] == requiredValue }
-        case .none:
-            return { _ in true }
         case let .or(lhs, rhs):
             let lhsClosure = Self.build(from: lhs, on: keyPath)
             let rhsClosure = Self.build(from: rhs, on: keyPath)

--- a/Sources/FilterClosure/Closure+OptionalComparablePredicate.swift
+++ b/Sources/FilterClosure/Closure+OptionalComparablePredicate.swift
@@ -26,7 +26,10 @@ extension Closure: OptionalComparablePredicate where Value: Comparable {
         case let .notNil(subFilter):
             return { value in
                 guard let value = value[keyPath: keyPath] else { return false }
-                return Closure<Value, Value>.build(from: subFilter)(value)
+                if let subFilter {
+                    return Closure<Value, Value>.build(from: subFilter)(value)
+                }
+                return true
             }
         case .isNil:
             return { $0[keyPath: keyPath] == nil }

--- a/Sources/FilterClosure/Closure+OptionalEquatablePredicate.swift
+++ b/Sources/FilterClosure/Closure+OptionalEquatablePredicate.swift
@@ -25,7 +25,10 @@ extension Closure: OptionalEquatablePredicate where Value: Equatable {
         case let .notNil(subFilter):
             return { value in
                 guard let value = value[keyPath: keyPath] else { return false }
-                return Closure<Value, Value>.build(from: subFilter)(value)
+                if let subFilter {
+                    return Closure<Value, Value>.build(from: subFilter)(value)
+                }
+                return true
             }
         case .isNil:
             return { $0[keyPath: keyPath] == nil }

--- a/Sources/FilterClosure/SendableClosure+ComparablePredicate.swift
+++ b/Sources/FilterClosure/SendableClosure+ComparablePredicate.swift
@@ -9,8 +9,6 @@
 import Filter
 import Foundation
 
-// swiftlint:disable cyclomatic_complexity
-
 extension SendableClosure: ComparablePredicate where Value: Comparable {
     /// Creates a closure `(Self) -> Bool` from a ComparableFilter
     ///
@@ -27,8 +25,6 @@ extension SendableClosure: ComparablePredicate where Value: Comparable {
             return { $0[keyPath: keyPath] > bound }
         case let .greaterThanOrEqualTo(bound):
             return { $0[keyPath: keyPath] >= bound }
-        case .none:
-            return { _ in true }
         case let .or(lhs, rhs):
             let lhsClosure = Self.build(from: lhs, on: keyPath)
             let rhsClosure = Self.build(from: rhs, on: keyPath)
@@ -53,5 +49,3 @@ extension SendableClosure: ComparablePredicate where Value: Comparable {
         }
     }
 }
-
-// swiftlint:enable cyclomatic_complexity

--- a/Sources/FilterClosure/SendableClosure+EquatablePredicate.swift
+++ b/Sources/FilterClosure/SendableClosure+EquatablePredicate.swift
@@ -19,8 +19,6 @@ extension SendableClosure: EquatablePredicate where Value: Equatable {
         switch filter {
         case let .equalTo(requiredValue):
             return { $0[keyPath: keyPath] == requiredValue }
-        case .none:
-            return { _ in true }
         case let .or(lhs, rhs):
             let lhsClosure = Self.build(from: lhs, on: keyPath)
             let rhsClosure = Self.build(from: rhs, on: keyPath)

--- a/Sources/FilterClosure/SendableClosure+OptionalComparablePredicate.swift
+++ b/Sources/FilterClosure/SendableClosure+OptionalComparablePredicate.swift
@@ -26,7 +26,10 @@ extension SendableClosure: OptionalComparablePredicate where Value: Comparable {
         case let .notNil(subFilter):
             return { value in
                 guard let value = value[keyPath: keyPath] else { return false }
-                return Closure<Value, Value>.build(from: subFilter)(value)
+                if let subFilter {
+                    return Closure<Value, Value>.build(from: subFilter)(value)
+                }
+                return true
             }
         case .isNil:
             return { $0[keyPath: keyPath] == nil }

--- a/Sources/FilterClosure/SendableClosure+OptionalEquatablePredicate.swift
+++ b/Sources/FilterClosure/SendableClosure+OptionalEquatablePredicate.swift
@@ -25,7 +25,10 @@ extension SendableClosure: OptionalEquatablePredicate where Value: Equatable {
         case let .notNil(subFilter):
             return { value in
                 guard let value = value[keyPath: keyPath] else { return false }
-                return Closure<Value, Value>.build(from: subFilter)(value)
+                if let subFilter {
+                    return Closure<Value, Value>.build(from: subFilter)(value)
+                }
+                return true
             }
         case .isNil:
             return { $0[keyPath: keyPath] == nil }

--- a/Sources/FilterNSPredicate/NSPredicate+AnyComparablePredicate.swift
+++ b/Sources/FilterNSPredicate/NSPredicate+AnyComparablePredicate.swift
@@ -9,8 +9,6 @@
 import Filter
 import Foundation
 
-// swiftlint:disable cyclomatic_complexity
-
 extension NSPredicate: AnyComparablePredicate {
     /// Creates a NSPredicate from a ComparableFilter
     ///
@@ -29,8 +27,6 @@ extension NSPredicate: AnyComparablePredicate {
             return NSExpression(forKeyPath: keyPath).greaterThan(NSExpression(forConstantValue: value))
         case let .greaterThanOrEqualTo(value):
             return NSExpression(forKeyPath: keyPath).greaterThanOrEqualTo(NSExpression(forConstantValue: value))
-        case .none:
-            return NSPredicate(value: true)
         case let .or(lhs, rhs):
             return .or([build(from: lhs, on: keyPath), build(from: rhs, on: keyPath)])
         case let .orMulti(predicates):
@@ -64,8 +60,6 @@ extension NSPredicate: AnyComparablePredicate {
             return NSExpression(forKeyPath: keyPath).greaterThan(NSExpression(forConstantValue: value))
         case let .greaterThanOrEqualTo(value):
             return NSExpression(forKeyPath: keyPath).greaterThanOrEqualTo(NSExpression(forConstantValue: value))
-        case .none:
-            return NSPredicate(value: true)
         case let .or(lhs, rhs):
             return .or([build(from: lhs, on: keyPath), build(from: rhs, on: keyPath)])
         case let .orMulti(predicates):
@@ -81,5 +75,3 @@ extension NSPredicate: AnyComparablePredicate {
         }
     }
 }
-
-// swiftlint:enable cyclomatic_complexity

--- a/Sources/FilterNSPredicate/NSPredicate+AnyEquatablePredicate.swift
+++ b/Sources/FilterNSPredicate/NSPredicate+AnyEquatablePredicate.swift
@@ -21,8 +21,6 @@ extension NSPredicate: AnyEquatablePredicate {
         switch filter {
         case let .equalTo(value):
             return NSExpression(forKeyPath: keyPath).equalTo(NSExpression(forConstantValue: value))
-        case .none:
-            return NSPredicate(value: true)
         case let .or(lhs, rhs):
             return .or([build(from: lhs, on: keyPath), build(from: rhs, on: keyPath)])
         case let .orMulti(predicates):
@@ -47,8 +45,6 @@ extension NSPredicate: AnyEquatablePredicate {
         switch filter {
         case let .equalTo(value):
             return NSExpression(forKeyPath: keyPath).equalTo(NSExpression(forConstantValue: value))
-        case .none:
-            return NSPredicate(value: true)
         case let .or(lhs, rhs):
             return .or([build(from: lhs, on: keyPath), build(from: rhs, on: keyPath)])
         case let .orMulti(predicates):

--- a/Sources/FilterNSPredicate/NSPredicate+OptionalAnyComparablePredicate.swift
+++ b/Sources/FilterNSPredicate/NSPredicate+OptionalAnyComparablePredicate.swift
@@ -26,10 +26,15 @@ extension NSPredicate: OptionalAnyComparablePredicate {
                 build(from: subFilter, on: keyPath),
             ])
         case let .notNil(subFilter):
-            return NSPredicate.and([
-                .not(NSExpression(forKeyPath: keyPath).equalTo(NSExpression(forConstantValue: nil))),
-                build(from: subFilter, on: keyPath),
-            ])
+            let notNil: NSPredicate = .not(NSExpression(forKeyPath: keyPath)
+                .equalTo(NSExpression(forConstantValue: nil)))
+            if let subFilter {
+                return NSPredicate.and([
+                    notNil,
+                    build(from: subFilter, on: keyPath),
+                ])
+            }
+            return notNil
         case .isNil:
             return NSExpression(forKeyPath: keyPath).equalTo(NSExpression(forConstantValue: nil))
         }

--- a/Sources/FilterNSPredicate/NSPredicate+OptionalAnyEquatablePredicate.swift
+++ b/Sources/FilterNSPredicate/NSPredicate+OptionalAnyEquatablePredicate.swift
@@ -25,10 +25,15 @@ extension NSPredicate: OptionalAnyEquatablePredicate {
                 build(from: subFilter, on: keyPath),
             ])
         case let .notNil(subFilter):
-            return NSPredicate.and([
-                .not(NSExpression(forKeyPath: keyPath).equalTo(NSExpression(forConstantValue: nil))),
-                build(from: subFilter, on: keyPath),
-            ])
+            let notNil: NSPredicate = .not(NSExpression(forKeyPath: keyPath)
+                .equalTo(NSExpression(forConstantValue: nil)))
+            if let subFilter {
+                return NSPredicate.and([
+                    notNil,
+                    build(from: subFilter, on: keyPath),
+                ])
+            }
+            return notNil
         case .isNil:
             return NSExpression(forKeyPath: keyPath).equalTo(NSExpression(forConstantValue: nil))
         }

--- a/Tests/FilterClosureTests/ComparableFilterClosureTests.swift
+++ b/Tests/FilterClosureTests/ComparableFilterClosureTests.swift
@@ -112,22 +112,20 @@ class ComparableFilterClosureTests: XCTestCase {
         XCTAssertEqual(result, [1])
     }
 
-    func testNone() {
-        let filter = ComparableFilter<Int>.none
-        let result = all.filter(Closure.build(from: filter))
-        XCTAssertEqual(result, [1, 2, 3, 4, 5])
-    }
-
     // MARK: Optional Wrapper
 
     func testOptionalOrNil() {
-        let filter = ComparableFilter<Int>.Optional.orNil(.none)
+        let filter = ComparableFilter<Int>.Optional.orNil(.equatable(.orMulti([
+            .equalTo(1),
+            .equalTo(4),
+            .equalTo(5),
+        ])))
         let result = allOptional.filter(Closure.build(from: filter))
-        XCTAssertEqual(result, [1, nil, 3, 4, 5])
+        XCTAssertEqual(result, [1, nil, 4, 5])
     }
 
     func testOptionalNotNil() {
-        let filter = ComparableFilter<Int>.Optional.notNil(.none)
+        let filter = ComparableFilter<Int>.Optional.notNil(nil)
         let result = allOptional.filter(Closure.build(from: filter))
         XCTAssertEqual(result, [1, 3, 4, 5])
     }

--- a/Tests/FilterClosureTests/ComparableFilterSendableClosureTests.swift
+++ b/Tests/FilterClosureTests/ComparableFilterSendableClosureTests.swift
@@ -10,7 +10,7 @@ import Filter
 import FilterClosure
 import XCTest
 
-class ComparableFilterSendableSendableClosureTests: XCTestCase {
+class ComparableFilterSendableClosureTests: XCTestCase {
     let all: [Int] = [1, 2, 3, 4, 5]
     let allOptional: [Int?] = [1, nil, 3, 4, 5]
 
@@ -112,22 +112,20 @@ class ComparableFilterSendableSendableClosureTests: XCTestCase {
         XCTAssertEqual(result, [1])
     }
 
-    func testNone() {
-        let filter = ComparableFilter<Int>.none
-        let result = all.filter(SendableClosure.build(from: filter))
-        XCTAssertEqual(result, [1, 2, 3, 4, 5])
-    }
-
     // MARK: Optional Wrapper
 
     func testOptionalOrNil() {
-        let filter = ComparableFilter<Int>.Optional.orNil(.none)
+        let filter = ComparableFilter<Int>.Optional.orNil(.equatable(.orMulti([
+            .equalTo(1),
+            .equalTo(4),
+            .equalTo(5),
+        ])))
         let result = allOptional.filter(SendableClosure.build(from: filter))
-        XCTAssertEqual(result, [1, nil, 3, 4, 5])
+        XCTAssertEqual(result, [1, nil, 4, 5])
     }
 
     func testOptionalNotNil() {
-        let filter = ComparableFilter<Int>.Optional.notNil(.none)
+        let filter = ComparableFilter<Int>.Optional.notNil(nil)
         let result = allOptional.filter(SendableClosure.build(from: filter))
         XCTAssertEqual(result, [1, 3, 4, 5])
     }

--- a/Tests/FilterClosureTests/EquatableFilterClosureTests.swift
+++ b/Tests/FilterClosureTests/EquatableFilterClosureTests.swift
@@ -28,22 +28,20 @@ class EquatableFilterClosureTests: XCTestCase {
         XCTAssertEqual(result, [3])
     }
 
-    func testNone() {
-        let filter = EquatableFilter<Int>.none
-        let result = all.filter(Closure.build(from: filter))
-        XCTAssertEqual(result, [1, 2, 3, 4, 5])
-    }
-
     // MARK: Optional Wrapper
 
     func testOptionalOrNil() {
-        let filter = EquatableFilter<Int>.Optional.orNil(.none)
+        let filter = EquatableFilter<Int>.Optional.orNil(.orMulti([
+            .equalTo(1),
+            .equalTo(4),
+            .equalTo(5),
+        ]))
         let result = allOptional.filter(Closure.build(from: filter))
-        XCTAssertEqual(result, [1, nil, 3, 4, 5])
+        XCTAssertEqual(result, [1, nil, 4, 5])
     }
 
     func testOptionalNotNil() {
-        let filter = EquatableFilter<Int>.Optional.notNil(.none)
+        let filter = EquatableFilter<Int>.Optional.notNil(nil)
         let result = allOptional.filter(Closure.build(from: filter))
         XCTAssertEqual(result, [1, 3, 4, 5])
     }

--- a/Tests/FilterClosureTests/EquatableFilterSendableClosureTests.swift
+++ b/Tests/FilterClosureTests/EquatableFilterSendableClosureTests.swift
@@ -28,22 +28,20 @@ class EquatableFilterSendableClosureTests: XCTestCase {
         XCTAssertEqual(result, [3])
     }
 
-    func testNone() {
-        let filter = EquatableFilter<Int>.none
-        let result = all.filter(SendableClosure.build(from: filter))
-        XCTAssertEqual(result, [1, 2, 3, 4, 5])
-    }
-
     // MARK: Optional Wrapper
 
     func testOptionalOrNil() {
-        let filter = EquatableFilter<Int>.Optional.orNil(.none)
+        let filter = EquatableFilter<Int>.Optional.orNil(.orMulti([
+            .equalTo(1),
+            .equalTo(4),
+            .equalTo(5),
+        ]))
         let result = allOptional.filter(SendableClosure.build(from: filter))
-        XCTAssertEqual(result, [1, nil, 3, 4, 5])
+        XCTAssertEqual(result, [1, nil, 4, 5])
     }
 
     func testOptionalNotNil() {
-        let filter = EquatableFilter<Int>.Optional.notNil(.none)
+        let filter = EquatableFilter<Int>.Optional.notNil(nil)
         let result = allOptional.filter(SendableClosure.build(from: filter))
         XCTAssertEqual(result, [1, 3, 4, 5])
     }

--- a/Tests/FilterNSPredicateTests/ComparableFilterNSPredicateTests.swift
+++ b/Tests/FilterNSPredicateTests/ComparableFilterNSPredicateTests.swift
@@ -112,22 +112,20 @@ class ComparableFilterNSPredicateTests: XCTestCase {
         XCTAssertEqual(result, [1])
     }
 
-    func testNone() {
-        let filter = ComparableFilter<Int>.none
-        let result = all.filter(NSPredicate.build(from: filter).closure)
-        XCTAssertEqual(result, [1, 2, 3, 4, 5])
-    }
-
     // MARK: Optional Wrapper
 
     func testOptionalOrNil() {
-        let filter = ComparableFilter<Int>.Optional.orNil(.none)
+        let filter = ComparableFilter<Int>.Optional.orNil(.equatable(.orMulti([
+            .equalTo(1),
+            .equalTo(4),
+            .equalTo(5),
+        ])))
         let result = allOptional.filter(NSPredicate.build(from: filter).closure)
-        XCTAssertEqual(result, [1, nil, 3, 4, 5])
+        XCTAssertEqual(result, [1, nil, 4, 5])
     }
 
     func testOptionalNotNil() {
-        let filter = ComparableFilter<Int>.Optional.notNil(.none)
+        let filter = ComparableFilter<Int>.Optional.notNil(nil)
         let result = allOptional.filter(NSPredicate.build(from: filter).closure)
         XCTAssertEqual(result, [1, 3, 4, 5])
     }

--- a/Tests/FilterNSPredicateTests/EquatableFilterNSPredicateTests.swift
+++ b/Tests/FilterNSPredicateTests/EquatableFilterNSPredicateTests.swift
@@ -28,22 +28,20 @@ class EquatableFilterNSPredicateTests: XCTestCase {
         XCTAssertEqual(result, [3])
     }
 
-    func testNone() {
-        let filter = EquatableFilter<Int>.none
-        let result = all.filter(NSPredicate.build(from: filter).closure)
-        XCTAssertEqual(result, [1, 2, 3, 4, 5])
-    }
-
     // MARK: Optional Wrapper
 
     func testOptionalOrNil() {
-        let filter = EquatableFilter<Int>.Optional.orNil(.none)
+        let filter = EquatableFilter<Int>.Optional.orNil(.orMulti([
+            .equalTo(1),
+            .equalTo(4),
+            .equalTo(5),
+        ]))
         let result = allOptional.filter(NSPredicate.build(from: filter).closure)
-        XCTAssertEqual(result, [1, nil, 3, 4, 5])
+        XCTAssertEqual(result, [1, nil, 4, 5])
     }
 
     func testOptionalNotNil() {
-        let filter = EquatableFilter<Int>.Optional.notNil(.none)
+        let filter = EquatableFilter<Int>.Optional.notNil(nil)
         let result = allOptional.filter(NSPredicate.build(from: filter).closure)
         XCTAssertEqual(result, [1, 3, 4, 5])
     }


### PR DESCRIPTION
Remove `none` case from EquatableFilter and ComparableFilter in favor of using Optionals

feature/remove-none-cases